### PR TITLE
fix: aot compilation for angular < 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "server": "node server/app.js",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "prepare": "npm run build"
+    "prepare": "npm run build && mv dist/ngx-flow ./ -f"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test:ci": "ng test ngx-flow --watch=false --browsers ChromeHeadless --code-coverage",
     "server": "node server/app.js",
     "lint": "ng lint",
-    "e2e": "ng e2e",
-    "prepare": "npm run build && mv dist/ngx-flow ./ -f"
+    "e2e": "ng e2e"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,19 +1,17 @@
 {
   "name": "ngx-flow-demo",
   "version": "0.0.0",
-  "files": [
-    "dist/ngx-flow"
-  ],
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build ngx-flow --prod",
+    "build": "ng build ngx-flow --prod && cp {README.md,LICENSE} ./dist/ngx-flow/",
     "test": "ng test ngx-flow",
     "test:ci": "ng test ngx-flow --watch=false --browsers ChromeHeadless --code-coverage",
     "server": "node server/app.js",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },
+  "private": true,
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@flowjs/ngx-flow",
+  "name": "ngx-flow-demo",
   "version": "0.0.0",
   "files": [
     "dist/ngx-flow"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngx-flow-demo",
+  "name": "@flowjs/ngx-flow",
   "version": "0.0.0",
   "files": [
     "dist/ngx-flow"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "server": "node server/app.js",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "prepack": "npm run build"
+    "prepare": "npm run build"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
   "name": "ngx-flow-demo",
   "version": "0.0.0",
+  "files": [
+    "dist/ngx-flow"
+  ],
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build ngx-flow --prod && cp {README.md,LICENSE} ./dist/ngx-flow/",
+    "build": "ng build ngx-flow --prod",
     "test": "ng test ngx-flow",
     "test:ci": "ng test ngx-flow --watch=false --browsers ChromeHeadless --code-coverage",
     "server": "node server/app.js",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "prepack": "npm run build"
   },
-  "private": true,
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged"

--- a/projects/ngx-flow/src/lib/ngx-flow.module.ts
+++ b/projects/ngx-flow/src/lib/ngx-flow.module.ts
@@ -7,6 +7,9 @@ import { FlowDirective } from './flow.directive';
 import { SrcDirective } from './src.directive';
 
 const directives = [ButtonDirective, SrcDirective, DropDirective, FlowDirective];
+export function flowFactory() {
+  return Flow;
+}
 
 @NgModule({
   imports: [],
@@ -14,7 +17,7 @@ const directives = [ButtonDirective, SrcDirective, DropDirective, FlowDirective]
   providers: [
     {
       provide: FlowInjectionToken,
-      useValue: Flow
+      useFactory: flowFactory
     }
   ],
   exports: directives


### PR DESCRIPTION
## Description

AOT compilation in Angular < 9 is having issues due to using the default exported value from FlowJS.

Fix this by using a factory as default. 

This will have no impact on anything using `useValue` as this is doing the same thing, just in a separate step.